### PR TITLE
Use dataclasses for struct like classes

### DIFF
--- a/dploot/triage/browser.py
+++ b/dploot/triage/browser.py
@@ -13,14 +13,15 @@ from dploot.lib.target import Target
 from dploot.lib.utils import datetime_to_time
 from dploot.lib.wmi import DPLootWmiExec
 from dploot.triage.masterkeys import Masterkey
+from dataclasses import dataclass
 
+@dataclass
 class LoginData:
-    def __init__(self, winuser: str, browser:str, url:str, username:str, password:str):
-        self.winuser = winuser
-        self.browser = browser
-        self.url = url
-        self.username = username
-        self.password = password
+    winuser: str
+    browser: str
+    url: str
+    username: str
+    password: str
 
     def dump(self) -> None:
         print('[%s LOGIN DATA]' % self.browser.upper())
@@ -33,17 +34,17 @@ class LoginData:
     def dump_quiet(self) -> None:
         print("[%s] %s - %s:%s" % (self.browser.upper(), self.url, self.username, self.password))
 
+@dataclass
 class Cookie:
-    def __init__(self, winuser: str, browser:str, host:str, path: str, cookie_name:str, cookie_value:str, creation_utc:str, expires_utc:str, last_access_utc:str):
-        self.winuser = winuser
-        self.browser = browser
-        self.host = host
-        self.path = path
-        self.cookie_name = cookie_name
-        self.cookie_value = cookie_value
-        self.creation_utc = creation_utc
-        self.expires_utc = expires_utc
-        self.last_access_utc = last_access_utc
+    winuser: str
+    browser:str
+    host:str
+    path: str
+    cookie_name:str
+    cookie_value:str
+    creation_utc:str
+    expires_utc:str
+    last_access_utc:str
 
     def dump(self) -> None:
         print('[%s COOKIE DATA]' % self.browser.upper())

--- a/dploot/triage/certificates.py
+++ b/dploot/triage/certificates.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import ntpath
 from typing import Dict, List, Tuple
+from dataclasses import dataclass
 
 from impacket.dcerpc.v5 import rrp
 
@@ -23,15 +24,15 @@ from dploot.triage.masterkeys import Masterkey
 
 PRINCIPAL_NAME = x509.ObjectIdentifier("1.3.6.1.4.1.311.20.2.3")
 
+@dataclass
 class Certificate:
-    def __init__(self, winuser: str, cert:x509.Certificate, pkey: PrivateKeyTypes, pfx: bytes, username: str, filename: str, clientauth: bool):
-        self.winuser = winuser
-        self.cert = cert
-        self.pkey = pkey
-        self.pfx = pfx
-        self.username = username
-        self.filename = filename
-        self.clientauth = clientauth
+    winuser: str
+    cert: x509.Certificate
+    pkey: PrivateKeyTypes
+    pfx: bytes
+    username: str
+    filename: str
+    clientauth: bool
 
     def dump(self) -> None:
         print('Issuer:\t\t\t%s' % str(self.cert.issuer.rfc4514_string()))

--- a/dploot/triage/credentials.py
+++ b/dploot/triage/credentials.py
@@ -1,6 +1,7 @@
 import logging
 import ntpath
 from typing import Any, List
+from dataclasses import dataclass
 
 from impacket.dpapi import CREDENTIAL_BLOB
 
@@ -10,15 +11,15 @@ from dploot.lib.target import Target
 from dploot.lib.utils import is_credfile
 from dploot.triage.masterkeys import Masterkey
 
+@dataclass
 class Credential:
-    def __init__(self, winuser: str, credblob: "CREDENTIAL_BLOB | Any", target: str, description: str, unknown: str, username: str, password: str):
-        self.winuser = winuser
-        self.credblob = credblob
-        self.target = target
-        self.description = description
-        self.unknown = unknown
-        self.username = username
-        self.password = password
+    winuser: str
+    credblob: "CREDENTIAL_BLOB | Any"
+    target: str
+    description: str
+    unknown: str
+    username: str
+    password: str
 
     def dump(self) -> None:
         self.credblob.dump()

--- a/dploot/triage/rdg.py
+++ b/dploot/triage/rdg.py
@@ -3,19 +3,20 @@ import ntpath
 from typing import Any, List, Tuple
 import xml.etree.ElementTree as ET
 import base64
+from dataclasses import dataclass
 
 from dploot.lib.dpapi import decrypt_blob, find_masterkey_for_blob
 from dploot.lib.smb import DPLootSMBConnection
 from dploot.lib.target import Target
 from dploot.triage.masterkeys import Masterkey
 
+@dataclass
 class RDGCred:
-    def __init__(self, type, profile_name, username, password, server_name = None) -> None:
-        self.type = type
-        self.profile_name = profile_name
-        self.server_name = server_name
-        self.username = username
-        self.password = password
+    type: str
+    profile_name: str
+    username: str
+    password: str
+    server_name: str = None
 
     def dump(self) -> None:
         if self.type == 'cred':
@@ -44,17 +45,17 @@ class RDGCred:
         elif self.type == 'server':
             print("[RDG] %s - %s - %s:%s" % (self.profile_name, self.server_name, self.username, self.password.decode('latin-1')))
 
+@dataclass
 class RDCMANFile:
-    def __init__(self, winuser: str, filepath:str, rdg_creds:List[RDGCred]) -> None:
-        self.winuser = winuser
-        self.filepath = filepath
-        self.rdg_creds = rdg_creds
+    winuser: str
+    filepath: str
+    rdg_creds: List[RDGCred]
 
+@dataclass
 class RDGFile:
-    def __init__(self, winuser: str, filepath:str, rdg_creds:List[RDGCred]) -> None:
-        self.winuser = winuser
-        self.filepath = filepath
-        self.rdg_creds = rdg_creds
+    winuser: str
+    filepath: str
+    rdg_creds: List[RDGCred]
 
 class RDGTriage:
 


### PR DESCRIPTION
Classes that are purely used as attribute sets are converted into dataclasses to avoid setting the properties manually in `__init__`. The following classes were changed:
- browser.py: `LoginData`, `Cookie`
- certificate.py: `Certificate`
- credentials.py: `Credential`
- rdg.py: `RDGCred`, `RDCMANFile`, `RDGFile`
Since dataclasses were introduced in python 3.7, dataclasses should hopefully be supported by this project.