### PR TITLE
Adds LOCAL target for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ $ dploot machinecertificates -d waza.local -u Administrator -p 'Password!123' 19
 [-] Writting certificate to DESKTOP-OJ3N8TJ.waza.local_796449B12B788ABA.pfx
 ```
 
+### With offline access to the Windows' filesystem
+
+A different way of gaining local administrator access to a system, for instance via physical access, extracting the drive and mounting the filesystem directly on your machine. To use this mode, specify `LOCAL` as the target. By default the target filesystem is expected to be the current directory, you can specify a different path with `-root`:
+
+```text
+$ dploot sccm -root /media/C_drive/ LOCAL
+[*] Connected to LOCAL as \None (admin)
+```
+
+It can still be useful to give valid username and password as arguments, which will be used to decrypt masterkeys (see the instructions in [User Triage](#user-triage) below):
+```text
+$ dploot masterkeys -root /mnt -u bob -p Password LOCAL
+[*] Connected to LOCAL as \bob (admin)
+```
+
 ### As a domain administrator (or equivalent)
 
 If you have domain admin privileges, you can obtain the domain DPAPI backup key with the backupkey command. This key can decrypt any DPAPI masterkeys for domain users and computers, and it will never change. Therefore, this key allow attacker to loot any DPAPI protected password realted to a domain user.
@@ -757,6 +772,3 @@ Those projects helped a lot in writting this tool:
 - [DonPAPI](https://github.com/login-securite/DonPAPI) by [LoginSecurite](https://twitter.com/LoginSecurite)
 - [wifi-squid](https://github.com/K-Mistele/wifi-squid) by [0xBlacklight](https://twitter.com/0xBlacklight)
 
-## TODO
-
-- Implement LOCAL triage (with extracted stuff)

--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ Those projects helped a lot in writting this tool:
 - [SharpDPAPI](https://github.com/GhostPack/SharpDPAPI) by [Harmj0y](https://twitter.com/harmj0y)
 - [Mimikatz](https://github.com/gentilkiwi/mimikatz/) by [gentilkiwi](https://twitter.com/gentilkiwi)
 - [DonPAPI](https://github.com/login-securite/DonPAPI) by [LoginSecurite](https://twitter.com/LoginSecurite)
+- [wifi-squid](https://github.com/K-Mistele/wifi-squid) by [0xBlacklight](https://twitter.com/0xBlacklight)
 
 ## TODO
 

--- a/dploot/action/backupkey.py
+++ b/dploot/action/backupkey.py
@@ -32,6 +32,9 @@ class BackupkeyAction:
         if self.conn.connect() is None:
             logging.error("Could not connect to %s" % self.target.address)
             sys.exit(1)
+        if self.conn.local_session:
+            logging.error("Backup key is not implemented with LOCAL target.")
+            sys.exit(1)
 
     def run(self) -> None:
         self.connect()

--- a/dploot/action/masterkeys.py
+++ b/dploot/action/masterkeys.py
@@ -99,12 +99,12 @@ def parse_masterkeys_options(options: argparse.Namespace, target: Target) -> Tup
             logging.error(str(e))
             sys.exit(1)
 
-    if target.password != '':
+    if target.password is not None and target.password != '':
         if passwords is None:
             passwords = dict()
         passwords[target.username] = target.password
 
-    if target.nthash != '':
+    if target.nthash is not None and target.nthash != '':
         if nthashes is None:
             nthashes = dict()
         nthashes[target.username] = target.nthash.lower()

--- a/dploot/entry.py
+++ b/dploot/entry.py
@@ -75,6 +75,7 @@ def main() -> None:
     else:
         logging.getLogger().setLevel(logging.INFO)
 
+    logging.debug(f"{options=}")
     try:
         actions[options.action](options)
     except Exception as e:

--- a/dploot/lib/smb.py
+++ b/dploot/lib/smb.py
@@ -249,7 +249,6 @@ class DPLootLocal(DPLootSMBConnection):
         self.smb_session   = DPLootDummySession()
         # the following are functions that should never be called on this class.
         self.enable_remoteops   = None
-        self.listPath           = None
         self.reconnect          = None
 
         #logging.debug(f"DPLootLocal.__init__ returning from {self}. taregt is {target}")
@@ -290,6 +289,14 @@ class DPLootLocal(DPLootSMBConnection):
         # logging.debug(f"remote_list_dir called with {path}, returning {result} ")
         return result
 
+    def listPath(self, shareName:str = 'C$', path:str = None, password:str = None):
+        if path[-2:] == r'\*':
+            return self.remote_list_dir(shareName, path[:-2], wildcard=True)
+        if path[-1] == '*':
+            return self.remote_list_dir(shareName, path[:-1], wildcard=True)
+        else:
+            raise NotImplementedError("Not implemented for wildcard == False")
+    
     def readFile(self, shareName, path, mode = FILE_OPEN, offset = 0, password = None, shareAccessMode = FILE_SHARE_READ, bypass_shared_violation = False) -> bytes:
         # logging.debug(f"readFile called with {path}")
         with open(os.path.join(self.target.local_root, path.replace('\\', os.sep)), 'rb') as f:

--- a/dploot/lib/smb.py
+++ b/dploot/lib/smb.py
@@ -214,6 +214,7 @@ class DPLootRemoteSMBConnection(DPLootSMBConnection):
                     offset  += len(bytesRead)
                     data += bytesRead
         except Exception as e:
+            logging.debug(f"Exception occurred while trying to read {path}: {e}")
             if 'STATUS_OBJECT_PATH_NOT_FOUND' in str(e):
                 pass
             elif 'STATUS_OBJECT_NAME_NOT_FOUND' in str(e):
@@ -308,8 +309,13 @@ class DPLootLocalSMBConnection(DPLootSMBConnection):
 
     def readFile(self, shareName, path, mode = FILE_OPEN, offset = 0, password = None, shareAccessMode = FILE_SHARE_READ, bypass_shared_violation = False) -> bytes:
         # logging.debug(f"readFile called with {path}")
-        with open(os.path.join(self.target.local_root, path.replace('\\', os.sep)), 'rb') as f:
-            data=f.read()
+        data = None
+        try:
+            with open(os.path.join(self.target.local_root, path.replace('\\', os.sep)), 'rb') as f:
+                data=f.read()
+        except Exception as e:
+            logging.debug(f"Exception occurred while trying to read {path}: {e}")
+
         return data
 
 class DPLootDummySession():

--- a/dploot/lib/target.py
+++ b/dploot/lib/target.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 class Target:
     def __init__(self) -> None:
@@ -14,58 +15,31 @@ class Target:
         self.use_kcache: bool = False
         self.dc_ip: str = None
         self.aesKey: str = None
+        self.local_root: str = None
+        self.is_local: bool = False
 
     @staticmethod
     def from_options(options) -> "Target":
-        self = Target()
 
-        username = options.username
-
-        domain = options.domain
-
-        if domain is None:
-            domain = ""
-
-        password = options.password
-        if (
-            not password
-            and username != ""
-            and options.hashes is None
-            and options.aesKey is None
-            and options.no_pass is not True
-        ):
-            from getpass import getpass
-
-            password = getpass("Password:")
-        hashes = options.hashes
-        if hashes is not None:
-            hashes = hashes.split(':')
-            if len(hashes) == 1:
-                (nthash,) = hashes
-                lmhash = nthash
-            else:
-                lmhash, nthash = hashes
-        else:
-            nthash = ''
-            lmhash = ''
-        
         if options.dc_ip is None:
             options.dc_ip = options.target
 
-        self.domain = domain
-        self.username = username
-        self.password = password
-        self.address = options.target
-        self.lmhash = lmhash
-        self.nthash = nthash
-        self.do_kerberos = options.k or options.aesKey is not None or options.use_kcache
-        self.kdcHost = options.kdcHost
-        self.use_kcache = options.use_kcache
-        self.dc_ip = options.dc_ip
-        self.aesKey = options.aesKey
-
-        return self
-
+        return Target.create(
+            domain  = options.domain,
+            username = options.username,
+            password = options.password,
+            target   = options.target,
+            hashes   = options.hashes,
+            lmhash   = None,
+            nthash   = None,
+            do_kerberos = options.k ,
+            kdcHost    = options.kdcHost,
+            use_kcache = options.use_kcache,
+            no_pass    = options.no_pass,
+            dc_ip = options.dc_ip,
+            aesKey= options.aesKey,
+            local_root=options.localroot)
+       
     @staticmethod
     def create(domain: str = None,
         username: str = None,
@@ -79,9 +53,21 @@ class Target:
         use_kcache: bool = False,
         no_pass: bool = False,
         dc_ip: str = None,
-        aesKey: str = None) -> "Target":
+        aesKey: str = None,
+        local_root: str = None) -> "Target":
 
         self = Target()
+
+        if target == "LOCAL":
+            self.is_local = True
+        
+        if self.is_local is True:
+            if do_kerberos or use_kcache or kdcHost is not None:
+                print("Invalid options: Use kerberos does not make sense when target=LOCAL", file=sys.stderr)
+                sys.exit(1)
+            if dc_ip is not None and dc_ip != "LOCAL":
+                print("Invalid options: dc-ip conflicts with target=LOCAL", file=sys.stderr)
+                sys.exit(1)
 
         if domain is None:
             domain = ""
@@ -93,6 +79,7 @@ class Target:
             and aesKey is None
             and no_pass is not True
             and do_kerberos is not True
+            and self.is_local is not True
         ):
             from getpass import getpass
 
@@ -122,6 +109,8 @@ class Target:
         self.use_kcache = use_kcache
         self.dc_ip = dc_ip
         self.aesKey = aesKey
+        self.local_root = local_root
+
         return self
 
     def __repr__(self) -> str:
@@ -133,7 +122,7 @@ def add_target_argument_group(parser: argparse.ArgumentParser,) -> None:
         "target",
         action="store",
         metavar="<target name or address>",
-        help="Target ip or address",
+        help="Target ip or address, or LOCAL",
     )
 
     parser.add_argument(
@@ -195,3 +184,14 @@ def add_target_argument_group(parser: argparse.ArgumentParser,) -> None:
             "part (FQDN) specified in the target parameter"
         ),
     )
+    group.add_argument(
+        "-root",
+        action="store",
+        dest='localroot',
+        metavar='path',
+        default='.',
+        help=(
+            "Root directory (for local operations). This directory should contain Windows and Users subdirectories"
+        ),
+    )
+

--- a/dploot/lib/wmi.py
+++ b/dploot/lib/wmi.py
@@ -25,7 +25,8 @@ class DPLootWmiExec:
         self.__win32Process = None
 
     def run(self, command):
-        logging.getLogger("impacket").disabled = True
+        if logging.getLogger().level != logging.DEBUG:
+            logging.getLogger("impacket").disabled = True
         dcom = DCOMConnection(self.__addr, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                               self.__aesKey, oxidResolver=True, doKerberos=self.__doKerberos, kdcHost=self.__kdcHost)
         try:

--- a/dploot/triage/certificates.py
+++ b/dploot/triage/certificates.py
@@ -204,10 +204,13 @@ class CertificatesTriage:
                                 pkey_bytes = self.conn.readFile(self.share, filepath)
                                 if pkey_bytes is not None and self.masterkeys is not None:
                                     self.looted_files[pkey_guid] = pkey_bytes
-                                    masterkey = find_masterkey_for_privatekey_blob(pkey_bytes, masterkeys=self.masterkeys)
-                                    if masterkey is not None:
-                                        pkey = decrypt_privatekey(privatekey_bytes=pkey_bytes, masterkey=masterkey)
-                                        pkeys[hashlib.md5(pkey.public_key().export_key('DER')).hexdigest()] = (pkey_guid,pkey)
+                                    try:
+                                        masterkey = find_masterkey_for_privatekey_blob(pkey_bytes, masterkeys=self.masterkeys)
+                                        if masterkey is not None:
+                                            pkey = decrypt_privatekey(privatekey_bytes=pkey_bytes, masterkey=masterkey)
+                                            pkeys[hashlib.md5(pkey.public_key().export_key('DER')).hexdigest()] = (pkey_guid,pkey)
+                                    except Exception as e:
+                                        logging.debug(f'Exception encountered in {__name__}: {e}.')
         return pkeys
 
     def loot_certificates(self, certificates_paths: List[str]) -> Dict[str, x509.Certificate]:

--- a/dploot/triage/certificates.py
+++ b/dploot/triage/certificates.py
@@ -1,11 +1,13 @@
 import hashlib
 import logging
 import ntpath
+import os
 from typing import Dict, List, Tuple
 from dataclasses import dataclass
 
 from impacket.dcerpc.v5 import rrp
 from impacket.system_errors import ERROR_NO_MORE_ITEMS
+from impacket.winregistry import Registry
 
 from Cryptodome.PublicKey import RSA
 from cryptography import x509
@@ -84,7 +86,10 @@ class CertificatesTriage:
 
     def triage_system_certificates(self) -> List[Certificate]:
         logging.getLogger("impacket").disabled = True
-        self.conn.enable_remoteops()
+        if self.conn.local_session:
+            self.conn.enable_localops(os.path.join(self.target.local_root, r'Windows/System32/config/SYSTEM'))
+        else:
+            self.conn.enable_remoteops()
         certificates = []
         pkeys = self.loot_privatekeys()
         certs = self.loot_system_certificates()
@@ -94,44 +99,69 @@ class CertificatesTriage:
 
     def loot_system_certificates(self) -> Dict[str,x509.Certificate]:
         my_certificates_key = 'SOFTWARE\\Microsoft\\SystemCertificates\\MY\\Certificates'
-        ans = rrp.hOpenLocalMachine(self.conn.remote_ops._RemoteOperations__rrp)
-        regHandle = ans['phKey']
         certificate_keys = []
         certificates = {}
-        ans = rrp.hBaseRegOpenKey(self.conn.remote_ops._RemoteOperations__rrp, regHandle, my_certificates_key, samDesired=rrp.KEY_ENUMERATE_SUB_KEYS)
-        keyHandle = ans['phkResult']
-        i = 0
-        while True:
-            try:
-                enum_ans = rrp.hBaseRegEnumKey(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, i)
-                certificate_keys.append(enum_ans['lpNameOut'][:-1])
-                i += 1
-            except rrp.DCERPCSessionError as e:
-                if e.get_error_code() == ERROR_NO_MORE_ITEMS:
-                    break
-            except Exception as e:
-                import traceback
-                traceback.print_exc()
-                logging.error(str(e))
-        rrp.hBaseRegCloseKey(self.conn.remote_ops._RemoteOperations__rrp, keyHandle)
-                    
-        for certificate_key in certificate_keys:
-            try:
-                regKey = my_certificates_key + '\\' + certificate_key
-                ans = rrp.hBaseRegOpenKey(self.conn.remote_ops._RemoteOperations__rrp, regHandle, regKey)
-                keyHandle = ans['phkResult']
-                _, certblob_bytes = rrp.hBaseRegQueryValue(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, 'Blob')
-                logging.debug("Found Certificates Blob: \\\\%s\\%s" %  (self.target.address,regKey))
+        if self.conn.local_session :
+            # open hive
+            reg_file_path = os.path.join(self.target.local_root, r'Windows/System32/config/SOFTWARE')
+            reg = Registry(reg_file_path, isRemote=False)
+
+            # open key
+            key_path=my_certificates_key[8:]
+            parentKey=reg.findKey(key_path)
+            if parentKey is None:
+                logging.error(f"Key {key_path} not found in {reg_file_path}")
+                return certificates
+            # for each certificate subkey (such as Microsoft\SystemCertificates\MY\Certificates\3FD2...)
+            for certificate_key in reg.enumKey(parentKey):
+                # get 'Blob' value
+                (_, certblob_bytes) = reg.getValue(ntpath.join(key_path, certificate_key, 'Blob'))
+                logging.debug("Found Certificates Blob: \\\\%s\\%s" %  (self.target.address,ntpath.join(my_certificates_key,certificate_key)))
                 certblob = CERTBLOB(certblob_bytes)
-                if certblob.der is not None:
-                    cert = self.der_to_cert(certblob.der)
-                    certificates[certificate_key] = cert
-                rrp.hBaseRegCloseKey(self.conn.remote_ops._RemoteOperations__rrp, keyHandle)
-            except Exception as e:
-                if logging.getLogger().level == logging.DEBUG:
+                if certblob.der is None: continue
+
+                # store in certificates dict
+                cert = self.der_to_cert(certblob.der)
+                certificates[certificate_key] = cert
+            reg.close()
+        else:
+            ans = rrp.hOpenLocalMachine(self.conn.remote_ops._RemoteOperations__rrp)
+            regHandle = ans['phKey']
+
+            ans = rrp.hBaseRegOpenKey(self.conn.remote_ops._RemoteOperations__rrp, regHandle, my_certificates_key, samDesired=rrp.KEY_ENUMERATE_SUB_KEYS)
+            keyHandle = ans['phkResult']
+            i = 0
+            while True:
+                try:
+                    enum_ans = rrp.hBaseRegEnumKey(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, i)
+                    certificate_keys.append(enum_ans['lpNameOut'][:-1])
+                    i += 1
+                except rrp.DCERPCSessionError as e:
+                    if e.get_error_code() == ERROR_NO_MORE_ITEMS:
+                        break
+                except Exception as e:
                     import traceback
                     traceback.print_exc()
-                    logging.debug(str(e))
+                    logging.error(str(e))
+            rrp.hBaseRegCloseKey(self.conn.remote_ops._RemoteOperations__rrp, keyHandle)
+
+            for certificate_key in certificate_keys:
+                try:
+                    regKey = my_certificates_key + '\\' + certificate_key
+                    ans = rrp.hBaseRegOpenKey(self.conn.remote_ops._RemoteOperations__rrp, regHandle, regKey)
+                    keyHandle = ans['phkResult']
+                    _, certblob_bytes = rrp.hBaseRegQueryValue(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, 'Blob')
+                    logging.debug("Found Certificates Blob: \\\\%s\\%s" %  (self.target.address,regKey))
+                    certblob = CERTBLOB(certblob_bytes)
+                    if certblob.der is not None:
+                        cert = self.der_to_cert(certblob.der)
+                        certificates[certificate_key] = cert
+                    rrp.hBaseRegCloseKey(self.conn.remote_ops._RemoteOperations__rrp, keyHandle)
+                except Exception as e:
+                    if logging.getLogger().level == logging.DEBUG:
+                        import traceback
+                        traceback.print_exc()
+                        logging.debug(str(e))
         return certificates
 
     def triage_certificates(self) -> List[Certificate]:

--- a/dploot/triage/masterkeys.py
+++ b/dploot/triage/masterkeys.py
@@ -77,26 +77,26 @@ class MasterkeysTriage:
                     LSA.dumpSecrets()
                     LSA.finish()
                     # dump secrets
-                    LSA = LSASecrets(SECURITYFileName, self.conn.bootkey, self.conn.remote_ops, isRemote=(not bool(self.conn.local_session)))
-                    print("LSA Cached Hashes:")
-                    LSA.dumpCachedHashes()
-                    print("LSA Secrets:")
-                    LSA.dumpSecrets()
-                    LSA.finish()
+                    # LSA = LSASecrets(SECURITYFileName, self.conn.bootkey, self.conn.remote_ops, isRemote=(not bool(self.conn.local_session)))
+                    # print("LSA Cached Hashes:")
+                    # LSA.dumpCachedHashes()
+                    # print("LSA Secrets:")
+                    # LSA.dumpSecrets()
+                    # LSA.finish()
                 except Exception as e:
                     logging.error('LSA hashes extraction failed: %s' % str(e))
 
                 # dump SAM
-                try:
-                    SAMFileName = \
-                        os.path.join(self.target.local_root, r'Windows/System32/config/SAM') if self.conn.local_session \
-                        else self.conn.remote_ops.saveSAM()
-                    SAM = SAMHashes(SAMFileName, self.conn.bootkey, isRemote = (not bool(self.conn.local_session)))
-                    print("SAM Secrets:")
-                    SAM.dump()
-                    SAM.finish()
-                except Exception as e:
-                    logging.error('SAM hashes extraction failed: %s' % str(e))
+                # try:
+                #     SAMFileName = \
+                #         os.path.join(self.target.local_root, r'Windows/System32/config/SAM') if self.conn.local_session \
+                #         else self.conn.remote_ops.saveSAM()
+                #     SAM = SAMHashes(SAMFileName, self.conn.bootkey, isRemote = (not bool(self.conn.local_session)))
+                #     print("SAM Secrets:")
+                #     SAM.dump()
+                #     SAM.finish()
+                # except Exception as e:
+                #     logging.error('SAM hashes extraction failed: %s' % str(e))
 
         system_protect_dir = self.conn.remote_list_dir(self.share, path=self.system_masterkeys_generic_path)
         for d in system_protect_dir:

--- a/dploot/triage/mobaxterm.py
+++ b/dploot/triage/mobaxterm.py
@@ -127,7 +127,7 @@ class MobaXtermTriage:
         mobaxterm_masterpassword = None
         mobaxterm_credentials = []
         try:
-            ntuser_dat_bytes = self.conn.readFile(self.share,self.ntuser_dat_path.format(username=user))
+            ntuser_dat_bytes = self.conn.readFile(self.share,self.ntuser_dat_path.format(username=user),bypass_shared_violation = True)
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/dploot/triage/mobaxterm.py
+++ b/dploot/triage/mobaxterm.py
@@ -3,7 +3,7 @@ import logging
 import ntpath
 import os
 import tempfile
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 from Cryptodome.Cipher import AES
 
 from impacket import winregistry
@@ -27,7 +27,7 @@ class MobaXtermPassword:
         iv = AES.new(key=masterpassword_key, mode=AES.MODE_ECB).encrypt(b'\x00' * AES.block_size)
         cipher = AES.new(key=masterpassword_key, iv=iv, mode=AES.MODE_CFB, segment_size=8)
         self.password = cipher.decrypt(b64decode(self.password_encrypted))
-    
+
     def dump(self) -> None:
         print("[MOBAXTERM PASSWORD]")
         print("Username:\t%s" % self.username)
@@ -90,7 +90,7 @@ class MobaXtermMasterPassword:
 
 class MobaXtermTriage:
     false_positive = [".","..", "desktop.ini","Public","Default","Default User","All Users"]
-    mobaxterm_registry_key_path = "Software\\Mobatek\\MobaXterm"
+    mobaxterm_registry_key_path = "SOFTWARE\\Mobatek\\MobaXterm"
     mobaxterm_sessionp_key_path = ntpath.join(mobaxterm_registry_key_path,"SessionP")
     mobaxterm_masterpassword_registry_key = "M"
     mobaxterm_passwords_registry_key = "P"
@@ -102,7 +102,7 @@ class MobaXtermTriage:
     def __init__(self, target: Target, conn: DPLootSMBConnection, masterkeys: List[Masterkey]) -> None:
         self.target = target
         self.conn = conn
-        
+
         self._users = None
         self.masterkeys = masterkeys
 
@@ -122,7 +122,7 @@ class MobaXtermTriage:
                     traceback.print_exc()
                     logging.debug(str(e))
         return mobaxterm_masterpassword_key, mobaxterm_credentials
-    
+
     def triage_mobaxterm_for_user(self, user: str, sid: str = None) -> Tuple[MobaXtermMasterPassword, List["MobaXtermCredential | MobaXtermPassword"]]:
         mobaxterm_masterpassword = None
         mobaxterm_credentials = []
@@ -139,11 +139,10 @@ class MobaXtermTriage:
             fh = tempfile.NamedTemporaryFile()
             fh.write(ntuser_dat_bytes)
             fh.seek(0)
-            
             # Extracting everything
             mobaxterm_masterpassword, mobaxterm_credentials =  self.extract_mobaxtermkeys_for_user_from_ntuser_dat(fh.name, user)
 
-        
+
         if mobaxterm_masterpassword is None:
             return None, []
         self.decrypt_mobaxterm_masterpassword(mobaxterm_masterpassword)
@@ -161,7 +160,7 @@ class MobaXtermTriage:
             # MobaXterm is not installed for this user
             return None, []
         logging.debug(f"Found MobaXterm registry keys for user {user}")
-        
+
         mobaxterm_masterpassword_key = None
         mobaxterm_credentials = []
 
@@ -174,7 +173,7 @@ class MobaXtermTriage:
                 traceback.print_exc()
                 logging.debug(str(e))
 
-            
+
         try:
             key_path = ntpath.join(self.mobaxterm_registry_key_path,self.mobaxterm_masterpassword_registry_key)
             new_key = reg.findKey(key_path)
@@ -200,12 +199,12 @@ class MobaXtermTriage:
             values = reg.enumValues(key)
             logging.debug(f"Found {len(values)} Mobaxterm Credentials for user {user}")
             for value in values:
-                data = reg.getValue(ntpath.join(key_path, value.decode('latin-1')))
-                username, password_encrypted = data[1].decode('latin-1').split(':')
+                _, data = reg.getValue(ntpath.join(key_path, value.decode('latin-1')))
+                username, password_encrypted = data.split(b':')
                 mobaxterm_credential = MobaXtermCredential(
                     winuser=user,
                     name=value.decode('latin-1'),
-                    username=username,
+                    username=username.decode('utf-16le', errors='backslashreplace'),
                     password_encrypted=password_encrypted,
                 )
                 mobaxterm_credentials.append(mobaxterm_credential)
@@ -239,10 +238,10 @@ class MobaXtermTriage:
         if entropy is not None:
             mobaxterm_masterpassword.entropy = entropy
         mobaxterm_masterpassword.decrypt_masterpassword_raw_value(masterkeys=self.masterkeys)
-    
+
     def decrypt_mobaxterm_password(self, mobaxterm_password: "MobaXtermCredential|MobaXtermPassword", mobaxterm_masterpassword: MobaXtermMasterPassword) -> None:
         mobaxterm_password.decrypt(masterpassword_key=mobaxterm_masterpassword.masterpassword_decrypted)
-    
+
     def extract_mobaxtermkeys_for_user_from_remote_registry(self, user: str, sid: str) -> Tuple[MobaXtermMasterPassword, List["MobaXtermCredential | MobaXtermPassword"]]:
         self.conn.enable_remoteops()
 
@@ -267,7 +266,7 @@ class MobaXtermTriage:
                 traceback.print_exc()
                 logging.error(f"Error while hBaseRegOpenKey HKU\\{regKey}: {e}")
             return None, []
-            
+
         # Extract M
         try:
             ans2 = rrp.hBaseRegOpenKey(self.conn.remote_ops._RemoteOperations__rrp, regHandle, ntpath.join(regKey,self.mobaxterm_masterpassword_registry_key), samDesired=rrp.MAXIMUM_ALLOWED | rrp.KEY_ENUMERATE_SUB_KEYS | rrp.KEY_QUERY_VALUE)
@@ -296,14 +295,14 @@ class MobaXtermTriage:
             while True:
                 try:
                     value = rrp.hBaseRegEnumValue(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, i)
-                    data = b''.join(value["lpData"]).decode('latin-1')
+                    data = b''.join(value["lpData"])
                     name = value["lpValueNameOut"].rstrip("\00")
-                    if ":" in data:
-                        username, password_encrypted = data.split(":")
+                    if b":" in data:
+                        username, password_encrypted = data.split(b":")
                         mobaxterm_credential = MobaXtermCredential(
                             winuser=user,
                             name=name,
-                            username=username,
+                            username=username.decode('utf-16le', errors='backslashreplace'),
                             password_encrypted=password_encrypted,
                         )
                     else:
@@ -321,14 +320,15 @@ class MobaXtermTriage:
         return mobaxterm_masterpassword_key, mobaxterm_credentials
 
     @property
-    def users(self) -> List[str]:
+    def users(self) -> Dict[str, str]:
+        """ returns dict of username: sid """
         if self._users is not None:
             return self._users
-        
+
         users = dict()
         sids = []
         userlist_key = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList"
-        
+
         if self.conn.local_session:
             reg = winregistry.Registry(os.path.join(self.conn.target.local_root, r'Windows/System32/config/SOFTWARE'), isRemote=False)
             parentKey=reg.findKey(userlist_key[8:])
@@ -338,16 +338,16 @@ class MobaXtermTriage:
                 return self._users
 
             sids=list(reg.enumKey(parentKey))
-            
+
             for sid in sids:
                 (v_type, v_data)= reg.getValue(ntpath.join(userlist_key[8:], sid, 'ProfileImagePath'))
                 profile_path=v_data.decode('utf-16le').rstrip("\0")
                 if r"%systemroot%" in profile_path:
                     continue
                 users[ntpath.basename(profile_path)] = sid
-            
+
             reg.close()
-    
+
         else:
             self.conn.enable_remoteops()
             ans = rrp.hOpenLocalMachine(self.conn.remote_ops._RemoteOperations__rrp)

--- a/dploot/triage/sccm.py
+++ b/dploot/triage/sccm.py
@@ -19,6 +19,8 @@ class SCCMCred:
         print('[NAA Account]')
         print('\tUsername:\t%s' % self.username.decode('latin-1'))
         print('\tPassword:\t%s' % self.password.decode('latin-1'))
+        logging.debug(f"\tBinary Username:\t{self.username}")
+        logging.debug(f"\tBinary Password:\t{self.username}")
 
 
     def dump_quiet(self) -> None:
@@ -32,6 +34,7 @@ class SCCMSecret:
     def dump(self) -> None:
         print('[Task sequences secret]')
         print('\tSecret:\t%s' % self.secret.decode('latin-1'))
+        logging.debug(f"Binary Secret:\t{self.secret}")
 
 
     def dump_quiet(self) -> None:
@@ -46,7 +49,8 @@ class SCCMCollection:
         print('[Collection Variable]')
         print("\tName:\t%s" % self.variable.decode('latin-1'))
         print("\tValue:\t%s" % self.value.decode('latin-1'))
-
+        logging.debug(f"Binary Name:\t{self.variable}")
+        logging.debug(f"Binary Value:\t{self.value}")
 
     def dump_quiet(self) -> None:
         print("[Collection] %s:%s" % (self.variable.decode('latin-1'), self.value.decode('latin-1')))

--- a/dploot/triage/sccm.py
+++ b/dploot/triage/sccm.py
@@ -22,7 +22,7 @@ class SCCM:
             print('\t%8s:\t%s' % (name.capitalize(), self.member_to_string(value)))
     
     def dump_quiet(self) -> None:
-        print(f'{self.quiet_description_header} {':'.join([self.member_to_string(_) for _ in self.__dict__.values()])}')
+        print(f'{self.quiet_description_header} {":".join([self.member_to_string(_) for _ in self.__dict__.values()])}')
     
     def __eq__(self, other) -> bool:
         for name in self.__dict__:

--- a/dploot/triage/wifi.py
+++ b/dploot/triage/wifi.py
@@ -143,7 +143,9 @@ class WifiTriage:
                                     masterkey = find_masterkey_for_blob(unhexlify(dpapi_blob.text), masterkeys=self.masterkeys)
                                     password = ''
                                     if masterkey is not None:
-                                        password = decrypt_blob(unhexlify(dpapi_blob.text), masterkey=masterkey).removesuffix(b'\x00')
+                                        cleartext = decrypt_blob(unhexlify(dpapi_blob.text), masterkey=masterkey)
+                                        if cleartext is not None:
+                                            password = cleartext.removesuffix(b'\x00')
                                     wifi_creds.append(WifiCred(
                                         ssid=ssid,
                                         auth=auth_type,
@@ -284,7 +286,9 @@ class WifiTriage:
                 return None
 
             blob = decrypt_blob(blob_bytes=msm_bytes,masterkey=masterkey)
-            # it seems decrypt_blob adds zeroes at then end of the cleartext...
+            # FIXME: it seems decrypt_blob sometimes adds zeroes at then end of the cleartext.
+            # when the result is passed to decrypt_blob again later, the DPAPI_BLOB built from blob_bytes
+            # will be valid, but its .rawData will contain extra bytes 
 
 
             # This (loosely) follows what is described in "Dumping Stored Enterprise Wifi Credentials with Invoke-WifiSquid"

--- a/dploot/triage/wifi.py
+++ b/dploot/triage/wifi.py
@@ -1,10 +1,14 @@
 from binascii import unhexlify
+import itertools
 import logging
 import ntpath
+import os
 from typing import Any, List
 from lxml import objectify
 
 from impacket.dcerpc.v5 import rrp
+from impacket.winregistry import Registry
+from impacket.system_errors import ERROR_NO_MORE_ITEMS, ERROR_FILE_NOT_FOUND
 
 from dploot.lib.dpapi import decrypt_blob, find_masterkey_for_blob
 
@@ -23,7 +27,7 @@ EAP_TYPES = {
 
 class WifiCred:
 
-    def __init__(self, ssid: str, auth: str, encryption: str, password: str = None, xml_data: Any = None, eap_username: str = None, eap_password: str = None) -> None:
+    def __init__(self, ssid: str, auth: str, encryption: str, password: str = None, xml_data: Any = None, eap_username: str = None, eap_domain: str = None, eap_password: str = None) -> None:
         self.ssid = ssid
         self.auth = auth
         self.encryption = encryption
@@ -36,6 +40,7 @@ class WifiCred:
         self.eap_type = None
         self.eap_username = eap_username
         self.eap_password = eap_password
+        self.eap_domain   = eap_domain
 
         if self.auth == 'WPA2' or self.auth == 'WPA':
             self.onex = getattr(self.xml_data.MSM.security, "{http://www.microsoft.com/networking/OneX/v1}OneX")
@@ -49,13 +54,16 @@ class WifiCred:
         if self.auth.upper() in ['WPAPSK', 'WPA2PSK','WPA3SAE']:
             print('AuthType:\t%s' % self.auth.upper())
             print('Encryption:\t%s' % self.encryption.upper())
-            print('Preshared key:\t%s' % self.password.decode('latin-1'))
+            print('Preshared key:\t%s' % self.password)
         elif self.auth.upper() in ['WPA', 'WPA2']:
             print('AuthType:\t%s EAP' % self.auth.upper())
             print('Encryption:\t%s' % self.encryption.upper())
             print('EAP Type:\t%s' % self.eap_type)
             if self.eap_username is not None and self.eap_password is not None:
-                print('Credentials:\t%s:%s' % (self.eap_username, self.eap_password))
+                print('Credentials:\t', end='')
+                if self.eap_domain is not None and len(self.eap_domain) != 0 :
+                    print('%s/' % self.eap_domain, end='')
+                print('%s:%s' % (self.eap_username, self.eap_password))
             print()
             self.dump_all_xml(self.eap_host_config)
         elif self.auth.upper() == 'OPEN':
@@ -95,7 +103,9 @@ class WifiTriage:
 
     system_wifi_generic_path = "ProgramData\\Microsoft\\Wlansvc\\Profiles\\Interfaces"
     share = 'C$'
-    eap_profiles_key = "SOFTWARE\\Microsoft\\Wlansvc\\Profiles\\%s"
+
+    eap_profiles_keys = (   "SOFTWARE\\Microsoft\\Wlansvc\\Profiles",
+                            "SOFTWARE\\Microsoft\\Wlansvc\\UserData\\Profiles" )
 
     def __init__(self, target: Target, conn: DPLootSMBConnection, masterkeys: List[Masterkey]) -> None:
         self.target = target
@@ -133,26 +143,27 @@ class WifiTriage:
                                     masterkey = find_masterkey_for_blob(unhexlify(dpapi_blob.text), masterkeys=self.masterkeys)
                                     password = ''
                                     if masterkey is not None:
-                                        password = decrypt_blob(unhexlify(dpapi_blob.text), masterkey=masterkey)
+                                        password = decrypt_blob(unhexlify(dpapi_blob.text), masterkey=masterkey).removesuffix(b'\x00')
                                     wifi_creds.append(WifiCred(
                                         ssid=ssid,
                                         auth=auth_type,
                                         encryption=encryption,
-                                        password=password,
+                                        password=password.decode('latin-1', errors='backslashreplace'),
                                         xml_data=main))
                                 elif auth_type in ['WPA', 'WPA2']:
                                     creds = self.triage_eap_creds(filename[:-4])
                                     eap_username = None
                                     eap_password = None
+                                    eap_domain   = None
                                     if creds is not None:
-                                        eap_username = creds[0].decode('latin-1')
-                                        eap_password = creds[1].decode('latin-1')
+                                        eap_username, eap_domain, eap_password = (_.decode('utf-8', errors='backslahreplace') for _ in creds)
                                     wifi_creds.append(WifiCred(
                                         ssid=ssid,
                                         auth=auth_type,
                                         encryption=encryption,
                                         xml_data=main,
                                         eap_username=eap_username,
+                                        eap_domain=eap_domain,
                                         eap_password=eap_password))    
                                 else:
                                     wifi_creds.append(WifiCred(
@@ -164,25 +175,146 @@ class WifiTriage:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
-                logging.debug(str(e))
+                logging.debug(f'{__name__}: {str(e)}')
             pass
         return wifi_creds
     
-    def triage_eap_creds(self, eap_profile):
+    def triage_eap_creds(self, eap_profile) -> list[bytes]:
         try:
-            self.conn.enable_remoteops()
-            regKey = self.eap_profiles_key % eap_profile
-            ans = rrp.hOpenLocalMachine(self.conn.remote_ops._RemoteOperations__rrp)
-            regHandle = ans['phKey']
-            ans = rrp.hBaseRegOpenKey(self.conn.remote_ops._RemoteOperations__rrp, regHandle, regKey)
-            keyHandle = ans['phkResult']
-            _, msm_bytes = rrp.hBaseRegQueryValue(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, 'MSMUserData')
+            if self.conn.local_session:
+                msm_bytes = None
+
+                # For each user:
+                for (user_sid, profile_path) in self.conn.getUsersProfiles().items():
+                #   open user registry file in user profile's dir/NTUser.dat
+                    profile_path = profile_path.replace('C:\\','').replace('\\', os.sep)
+                    reg_file_path = os.path.join(self.target.local_root, profile_path, 'NTUSER.DAT')
+
+                    reg = None
+                    
+                    # Workaround for a bug in impacket.winregistry.Registry:
+                    # if Registry() is called and raises an exception during initialisation (that you can handle),
+                    # the destruction of the (not initialized) Registry instance will raise an exception (that you cannot handle)
+                    if not os.path.isfile(reg_file_path):
+                        continue
+                    
+                    try:
+                        reg = Registry(reg_file_path, isRemote=False)
+                    except Exception as e:
+                        logger.debug(f"Exception while instantiating Registry({reg_file_path}): {e}. Continuing.")
+                        continue
+
+                #   check for network profile in both eap_profiles_keys
+                    for eap_profile_key in self.eap_profiles_keys:
+                #       retrieve MSMUserData
+                        msm_value = ntpath.join(eap_profile_key, eap_profile, 'MSMUserData')
+                        msm_tuple = reg.getValue(msm_value)
+                        if msm_tuple is None:
+                            continue
+                        msm_bytes = msm_tuple[1]
+                        break
+                               
+                if msm_bytes is None:
+                    # we searched the network profile in all found users, and could not find it.
+                    logging.debug(f'Could not find corresponding registry value')
+                    return None
+
+                logging.debug(f'Found profile in registry at HKU\\{user_sid}\\{ntpath.dirname(msm_value)}')
+
+            else:
+                self.conn.enable_remoteops()
+                dce = self.conn.remote_ops._RemoteOperations__rrp
+
+                # Open HKEY_USERS
+                ans = rrp.hOpenUsers(dce)
+                hRootKey = ans['phKey']
+
+                # for each subkey:
+                ans = rrp.hBaseRegOpenKey(dce, hRootKey, '', samDesired=rrp.MAXIMUM_ALLOWED | rrp.KEY_ENUMERATE_SUB_KEYS)
+                keyHandle = ans['phkResult']
+                user_sids = set()
+                i=0
+                while True:
+                    try:
+                        enum_ans = rrp.hBaseRegEnumKey(dce, keyHandle, i)
+                        i+=1
+                        user_sids.add(enum_ans['lpNameOut'][:-1])
+                    except rrp.DCERPCSessionError as e:
+                        if e.get_error_code() == ERROR_NO_MORE_ITEMS:
+                            break
+                    except Exception as e:
+                        import traceback
+                        traceback.print_exc()
+                        logging.error(str(e))
+                rrp.hBaseRegCloseKey(dce, keyHandle)
+                ans = keyHandle = None
+                
+                found = False
+                for sid, eap_profile_key in itertools.product(user_sids, self.eap_profiles_keys):
+                    # look for profile
+                    subKey = '\\'.join((sid , eap_profile_key, eap_profile))
+                    try:
+                        ans = rrp.hBaseRegOpenKey(dce, hRootKey, subKey)
+                        keyHandle = ans['phkResult']
+                        found = True
+                        break
+                    except rrp.DCERPCSessionError as e:
+                        if e.get_error_code() == ERROR_FILE_NOT_FOUND:
+                            continue
+                    except Exception as e:
+                        import traceback
+                        traceback.print_exc()
+                        logging.error(str(e))
+
+                if not found:
+                    logging.debug(f'Could not find corresponding registry key')
+                    return None
+
+                logging.debug(f'Found profile in registry at HKU\\{subKey}')
+
+                # retrieve MSMUserData                
+                keyHandle = ans['phkResult']
+                _, msm_bytes = rrp.hBaseRegQueryValue(self.conn.remote_ops._RemoteOperations__rrp, keyHandle, 'MSMUserData')
+
+                rrp.hBaseRegCloseKey(dce, keyHandle)
+                ans = keyHandle = None
+            
             masterkey = find_masterkey_for_blob(msm_bytes, masterkeys=self.masterkeys)
-            if masterkey is not None:
-                blob = decrypt_blob(blob_bytes=msm_bytes,masterkey=masterkey)
-                username = blob[176:].split(b'\0')[0]
-                password = blob[432:].split(b'\0')[1]
-                return (username, password)
+            if masterkey is None:
+                return None
+
+            blob = decrypt_blob(blob_bytes=msm_bytes,masterkey=masterkey)
+            # it seems decrypt_blob adds zeroes at then end of the cleartext...
+
+
+            # This (loosely) follows what is described in "Dumping Stored Enterprise Wifi Credentials with Invoke-WifiSquid"
+            # https://kylemistele.medium.com/dumping-stored-enterprise-wifi-credentials-with-invoke-wifisquid-5a7fe76f800 , 
+
+            prefix   = blob[168:176]
+            username = blob[176:].split(b'\0')[0]
+            domain   = blob[176:].split(b'\0')[1]
+            password = blob[432:].split(b'\0')[1]
+
+            # if prefix is [0x03, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00] the password is not encrypted
+            if prefix == b'\x04\x00\x00\x00\x02\x00\x00\x00' :
+                index = blob[176:].find(b'\x01\x00\x00\x00\xd0\x8c\x9d\xdf\x01')
+                if index == -1:
+                    logging.debug("Couldn't find password signature!")
+                    return (username, domain, password)
+                index += 176
+                msm_bytes = blob[index:]
+                masterkey = find_masterkey_for_blob(msm_bytes, masterkeys=self.masterkeys)
+
+                if masterkey is None:
+                    logging.info("Couldn't find key to decrypt password.")
+                    logging.info("Try saving machinemasterkeys and masterkeys in a file and launch again with this file as mkfile.")
+                    return (username, domain, password)
+
+                found_password = decrypt_blob(blob_bytes=msm_bytes,masterkey=masterkey)
+                if found_password is not None:
+                    password = found_password.rstrip(b'\x00')
+            return (username, domain, password)
+
         except Exception as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback


### PR DESCRIPTION
This PR adds a LOCAL target for use offline, with a mounted filesystem.
Example usage:
`dploot machinecertificates -root /mnt LOCAL` expects to find a Windows disk mounted in `/mnt`.

This has not been thoroughly tested, and currently lacks documentation, but almost all the original functionality is supported.

Most of the work is implemented in `dploot/lib/smb.py`: when an instance of `DPLootSMBConnection` is created with `LOCAL` in `target.address`, a `DPLootLocalSMBConnection` class is returned instead, which handles all the file operations locally. This way not much need to be changed in the calling code to handle local filesystem calls.

Some conditional calls have also been added in other classes for handling registry reads and cases where user and password are empty where they were not.

I have also added code to dump LSA and SAM secrets, as done in impacket's secretsdump, but it is currently commented out, adding much noise to the original output.