### PR TITLE
Bump lxml to fix build errors with Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ python = "^3.10.0"
 impacket = ">=0.10.0"
 cryptography = ">=40.0.1"
 pyasn1 = "^0.4.8"
-lxml = "4.9.3"
+lxml = ">=5.0.0-1"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.5.3"


### PR DESCRIPTION
lxml < 5.0.0-1 causes build errors for the latest stable Python release (3.13.0)

https://github.com/lxml/lxml/commit/c18f89b84f9254d026aa5c52c81cc9b4c982a187
https://github.com/Pennyw0rth/NetExec/issues/489