### PR TITLE
Handle case inconsistencies

### DIFF
--- a/dploot/lib/masterkey.py
+++ b/dploot/lib/masterkey.py
@@ -11,10 +11,10 @@ from dploot.lib.dpapi import decrypt_masterkey
 
 
 class Masterkey:
-    def __init__(self, guid, blob = None, sid = None, key = None, sha1 = None, user: str = "None") -> None:
+    def __init__(self, guid, blob = None, sid:str = None, key = None, sha1 = None, user: str = "None") -> None:
         self.guid = guid
         self.blob = blob
-        self.sid = sid
+        self.sid = str(sid).upper()
         self.user = user
 
         self.key = key

--- a/dploot/lib/utils.py
+++ b/dploot/lib/utils.py
@@ -34,7 +34,7 @@ def is_certificate_guid(value: str):
 
 
 def is_credfile(value: str):
-    guid = re.compile(r"[A-F0-9]{32}")
+    guid = re.compile(r"[A-F0-9a-f]{32}")
     return guid.match(value)
 
 

--- a/dploot/triage/__init__.py
+++ b/dploot/triage/__init__.py
@@ -6,13 +6,22 @@ from dploot.lib.smb import DPLootSMBConnection
 from dploot.lib.masterkey import Masterkey
 from dploot.lib.consts import FALSE_POSITIVES
 
+# simple class to check for false positive case insensitive
+class FalsePositive:
+    def __init__(self,
+                 false_positive: List[str] = FALSE_POSITIVES
+    ) -> None:
+        self.false_positive = list(map(lambda x:str(x).lower(), false_positive))
+
+    def contains(self, name):
+        return str(name).lower() in self.false_positive
+
 # Define base triage class.
 
-class Triage(ABC):
+class Triage:
     """
-    Abstract Class Definition for the DPLoot Triage Class.
+    Class Definition for the DPLoot Triage Class.
     """
-    @abstractmethod
     def __init__(
         self,
         target: Target,
@@ -26,6 +35,6 @@ class Triage(ABC):
         self.conn = conn
         self.masterkeys = masterkeys
         self.per_loot_callback = per_loot_callback
-        self.false_positive = false_positive
-        
+        self.false_positive = FalsePositive(false_positive)
+
         self.looted_files = {}

--- a/dploot/triage/browser.py
+++ b/dploot/triage/browser.py
@@ -235,35 +235,40 @@ class BrowserTriage(Triage):
                     f"Found {browser.upper()} AppData files for user {user}"
                 )
                 aesStateKey_json = json.loads(aesStateKey_bytes)
-                profiles = aesStateKey_json['profile']['profiles_order']
-                blob = base64.b64decode(aesStateKey_json["os_crypt"]["encrypted_key"])
-                if blob[:5] == b"DPAPI":
-                    dpapi_blob = blob[5:]
-                    masterkey = find_masterkey_for_blob(
-                        dpapi_blob, masterkeys=self.masterkeys
-                    )
-                    if masterkey is not None:
-                        aeskey = decrypt_blob(
-                            blob_bytes=dpapi_blob, masterkey=masterkey
-                        )
-                
-                if "app_bound_encrypted_key" in aesStateKey_json["os_crypt"]:
-                    app_bound_blob = base64.b64decode(aesStateKey_json["os_crypt"]["app_bound_encrypted_key"])
-                    dpapi_blob = app_bound_blob[4:] # Trim off APPB
-                    masterkey = find_masterkey_for_blob(
+                try:
+                    blob = base64.b64decode(aesStateKey_json["os_crypt"]["encrypted_key"])
+                    if blob[:5] == b"DPAPI":
+                        dpapi_blob = blob[5:]
+                        masterkey = find_masterkey_for_blob(
                             dpapi_blob, masterkeys=self.masterkeys
                         )
-                    if masterkey is not None:
-                        intermediate_key = decrypt_blob(
-                            blob_bytes=dpapi_blob, masterkey=masterkey
-                        )
+                        if masterkey is not None:
+                            aeskey = decrypt_blob(
+                                blob_bytes=dpapi_blob, masterkey=masterkey
+                            )
+
+                    if "app_bound_encrypted_key" in aesStateKey_json["os_crypt"]:
+                        app_bound_blob = base64.b64decode(aesStateKey_json["os_crypt"]["app_bound_encrypted_key"])
+                        dpapi_blob = app_bound_blob[4:] # Trim off APPB
                         masterkey = find_masterkey_for_blob(
-                            intermediate_key, masterkeys=self.masterkeys
-                        )
-                        if masterkey:
-                            app_bound_key = AppBoundKey(decrypt_blob(
-                                blob_bytes=intermediate_key, masterkey=masterkey
-                            )).key
+                                dpapi_blob, masterkeys=self.masterkeys
+                            )
+                        if masterkey is not None:
+                            intermediate_key = decrypt_blob(
+                                blob_bytes=dpapi_blob, masterkey=masterkey
+                            )
+                            masterkey = find_masterkey_for_blob(
+                                intermediate_key, masterkeys=self.masterkeys
+                            )
+                            if masterkey:
+                                app_bound_key = AppBoundKey(decrypt_blob(
+                                    blob_bytes=intermediate_key, masterkey=masterkey
+                                )).key
+                    profiles = aesStateKey_json['profile']['profiles_order']
+                except KeyError as e:
+                    logging.debug(f"Key not found! {repr(e)}")
+                    # logging.debug(f"{aesStateKey_json=}")
+
             for profile in profiles:
                 loginData_bytes = self.conn.readFile(
                     shareName=self.share,

--- a/dploot/triage/certificates.py
+++ b/dploot/triage/certificates.py
@@ -263,14 +263,14 @@ class CertificatesTriage(Triage):
             if pkeys_dir is not None:
                 for d in pkeys_dir:
                     if (
-                        d not in self.false_positive
+                        not self.false_positive.contains(d)
                         and d.is_directory() > 0
                         and (
                             d.get_longname()[:2].upper() == "S-"
                             or d.get_longname().upper() == "MachineKeys".upper()
                         )
                     ):
-                        sid = d.get_longname().upper()
+                        sid = d.get_longname()
                         pkeys_sid_path = ntpath.join(pkeys_path, sid)
                         pkeys_sid_dir = self.conn.remote_list_dir(
                             self.share, path=pkeys_sid_path
@@ -317,8 +317,7 @@ class CertificatesTriage(Triage):
         for cert_dir_path, cert_dir in certificates_dir.items():
             if cert_dir is not None:
                 for cert in cert_dir:
-                    if str(cert).lower() not in list(map(lambda x:x.lower(),self.false_positive)) \
-                        and cert.is_directory() == 0:
+                    if not self.false_positive.contains(cert) and cert.is_directory() == 0:
                         try:
                             certname = cert.get_longname()
                             certpath = ntpath.join(cert_dir_path, certname)

--- a/dploot/triage/credentials.py
+++ b/dploot/triage/credentials.py
@@ -135,7 +135,7 @@ class CredentialsTriage(Triage):
                                     description=cred["Description"].decode("utf-16le"),
                                     unknown=cred["Unknown"].decode("utf-16le"),
                                     username=cred["Username"].decode("utf-16le"),
-                                    password=cred["Unknown3"].decode("utf-16le"),
+                                    password=cred["Unknown3"].decode("latin1"),
                                 )
                             except UnicodeDecodeError:
                                 credential = Credential(
@@ -145,7 +145,7 @@ class CredentialsTriage(Triage):
                                     description=cred["Description"].decode("utf-16le"),
                                     unknown=cred["Unknown"].decode("utf-16le"),
                                     username=cred["Username"].decode("utf-16le"),
-                                    password=cred["Unknown3"].decode("latin-1"),
+                                    password=cred["Unknown3"].decode("utf-16le"),
                                 )
                             credentials.append(credential)
                             if self.per_loot_callback is not None:

--- a/dploot/triage/masterkeys.py
+++ b/dploot/triage/masterkeys.py
@@ -104,7 +104,7 @@ class MasterkeysTriage(Triage):
         )
         for d in system_protect_dir:
             if (
-                str(d).lower() not in list(map(lambda s:s.lower(), self.false_positive))
+                not self.false_positive.contains(d)
                 and d.is_directory() > 0
                 and d.get_longname()[:2].upper() == "S-"
             ):  # could be a better way to deal with sid
@@ -197,7 +197,7 @@ class MasterkeysTriage(Triage):
             return masterkeys
         for d in user_protect_dir:
             if (
-                str(d).lower() not in list(map(lambda x:x.lower(), self.false_positive))
+                not self.false_positive.contains(d)
                 and d.is_directory() > 0
                 and d.get_longname()[:2].upper() == "S-"
             ):  # could be a better way to deal with sid

--- a/dploot/triage/masterkeys.py
+++ b/dploot/triage/masterkeys.py
@@ -104,11 +104,11 @@ class MasterkeysTriage(Triage):
         )
         for d in system_protect_dir:
             if (
-                d not in self.false_positive
+                str(d).lower() not in list(map(lambda s:s.lower(), self.false_positive))
                 and d.is_directory() > 0
-                and d.get_longname()[:2] == "S-"
+                and d.get_longname()[:2].upper() == "S-"
             ):  # could be a better way to deal with sid
-                sid = d.get_longname()
+                sid = d.get_longname().upper()
                 system_protect_dir_sid_path = ntpath.join(
                     self.system_masterkeys_generic_path, sid
                 )
@@ -136,9 +136,9 @@ class MasterkeysTriage(Triage):
                                 masterkeys.append(masterkey)
                                 if self.per_loot_callback is not None:
                                     self.per_loot_callback(masterkey)
-                    elif f.is_directory() > 0 and f.get_longname() == "User":
+                    elif f.is_directory() > 0 and f.get_longname().upper() == "USER":
                         system_protect_dir_user_path = ntpath.join(
-                            system_protect_dir_sid_path, "User"
+                            system_protect_dir_sid_path, f.get_longname()
                         )
                         system_user_dir = self.conn.remote_list_dir(
                             self.share, path=system_protect_dir_user_path
@@ -197,11 +197,11 @@ class MasterkeysTriage(Triage):
             return masterkeys
         for d in user_protect_dir:
             if (
-                d not in self.false_positive
+                str(d).lower() not in list(map(lambda x:x.lower(), self.false_positive))
                 and d.is_directory() > 0
-                and d.get_longname()[:2] == "S-"
+                and d.get_longname()[:2].upper() == "S-"
             ):  # could be a better way to deal with sid
-                sid = d.get_longname()
+                sid = d.get_longname().upper()
                 user_masterkey_path_sid = ntpath.join(
                     ntpath.join(
                         ntpath.join("Users", user), self.user_masterkeys_generic_path

--- a/dploot/triage/vaults.py
+++ b/dploot/triage/vaults.py
@@ -191,15 +191,15 @@ class VaultsTriage(Triage):
                     filename = file.get_longname()
                     if (
                         filename != self.vpol_filename
-                        and filename not in self.false_positive
+                        and not self.false_positive.contains(filename)
                         and file.is_directory() == 0
-                        and filename[-4:] == "vcrd"
+                        and filename[-4:].lower() == "vcrd"
                     ):
                         vrcd_filepath = ntpath.join(vault_directory_path, filename)
                         vrcd_bytes = self.conn.readFile(self.share, vrcd_filepath, looted_files=self.looted_files)
                         if (
                             vrcd_bytes is not None
-                            and filename[-4:] in ["vsch", "vcrd"]
+                            and filename[-4:].lower() in ["vsch", "vcrd"]
                             and len(vpol_keys) > 0
                         ):
                             vault = decrypt_vcrd(vrcd_bytes, vpol_keys)

--- a/dploot/triage/wam.py
+++ b/dploot/triage/wam.py
@@ -213,7 +213,7 @@ class WamTriage(Triage):
         for file in tbc_dir:
             filename = file.get_longname()
             if filename[-6:].lower() ==".tbres" \
-                and filename.lower() not in list(map(lambda x:x.lower(), self.false_positive)) \
+                and not self.false_positive.contains(filename) \
                 and file.is_directory() == 0:
                 logging.debug(f"Got {filename} cache file for user {user}")
                 tbres_filepath = ntpath.join(tbc_user_path, filename)

--- a/dploot/triage/wam.py
+++ b/dploot/triage/wam.py
@@ -212,7 +212,9 @@ class WamTriage(Triage):
             return []
         for file in tbc_dir:
             filename = file.get_longname()
-            if filename[-6:] ==".tbres" and filename not in self.false_positive and file.is_directory() == 0:
+            if filename[-6:].lower() ==".tbres" \
+                and filename.lower() not in list(map(lambda x:x.lower(), self.false_positive)) \
+                and file.is_directory() == 0:
                 logging.debug(f"Got {filename} cache file for user {user}")
                 tbres_filepath = ntpath.join(tbc_user_path, filename)
                 data_bytes = self.conn.readFile(self.share, tbres_filepath, looted_files=self.looted_files)
@@ -224,7 +226,7 @@ class WamTriage(Triage):
                     if self.per_loot_callback is not None:
                         self.per_loot_callback(tbres_response_data)
                     tbres_responses_cache.append(tbres_response_data)
-        return tbres_responses_cache                
+        return tbres_responses_cache
 
     def decypt_tbres_file(self, tbres_file_data_bytes):
         tbres_json_data = json.loads(tbres_file_data_bytes.decode("utf-16le").rstrip("\x00"))

--- a/dploot/triage/wifi.py
+++ b/dploot/triage/wifi.py
@@ -156,7 +156,7 @@ class WifiTriage(Triage):
                 for directory in wifi_dir:
                     if (
                         directory.is_directory() > 0
-                        and directory.get_longname() not in self.false_positive
+                        and not self.false_positive.contains(directory.get_longname())
                     ):
                         wifi_interface_path = ntpath.join(
                             self.system_wifi_generic_path, directory.get_longname()
@@ -168,8 +168,8 @@ class WifiTriage(Triage):
                             filename = file.get_longname()
                             if (
                                 file.is_directory() == 0
-                                and filename not in self.false_positive
-                                and filename[-4:] == ".xml"
+                                and not self.false_positive.contains(filename)
+                                and filename[-4:].lower() == ".xml"
                             ):
                                 wifi_interface_filepath = ntpath.join(
                                     wifi_interface_path, filename

--- a/dploot/triage/wifi.py
+++ b/dploot/triage/wifi.py
@@ -198,7 +198,7 @@ class WifiTriage(Triage):
                                         unhexlify(dpapi_blob.text),
                                         masterkeys=self.masterkeys,
                                     )
-                                    password = ""
+                                    password = b''
                                     if masterkey is not None:
                                         cleartext = decrypt_blob(
                                             unhexlify(dpapi_blob.text),
@@ -263,13 +263,8 @@ class WifiTriage(Triage):
                 # For each user:
                 for user_sid, profile_path in self.conn.getUsersProfiles().items():
                     #   open user registry file in user profile's dir/NTUser.dat
-                    profile_path = profile_path.replace("C:\\", "").replace(
-                        "\\", os.sep
-                    )
-                    reg_file_path = os.path.join(
-                        self.target.local_root, profile_path, "NTUSER.DAT"
-                    )
-
+                    
+                    reg_file_path = self.conn.get_real_path(os.path.join(profile_path, "NTUSER.DAT"))
                     reg = None
 
                     # Workaround for a bug in impacket.winregistry.Registry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "dploot"
 version = "3.1.2"
+requires-pyhton = ">= 3.12"
 description = "DPAPI looting remotely in Python"
 readme = "README.md"
 homepage = "https://github.com/zblurx/dploot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.poetry]
 name = "dploot"
 version = "3.1.2"
-requires-pyhton = ">= 3.12"
 description = "DPAPI looting remotely in Python"
 readme = "README.md"
 homepage = "https://github.com/zblurx/dploot"


### PR DESCRIPTION
When using dploot on linux, the windows filesystem is mounted either case sensitive (with ntfs-3g), or case insensitive but all existing files are reported as lowercase (with lowntfs-3g). This can lead to some missing data when dploot matches some string with some part of the filename.

This PR corrects this,  by using pathlib's Path.glob() function with case_sensitive parameter. This requires Python 3.12 at least.

