### PR TITLE
Allow newer versions of pyasn1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dploot = "dploot.entry:main"
 python = "^3.10.0"
 impacket = ">=0.12.0"
 cryptography = ">=40.0.1"
-pyasn1 = "^0.4.8"
+pyasn1 = ">=0.4.8"
 lxml = ">=5.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Hi,

for an upcoming project i would need to allow newer versions of pyasn1 due to dependency restrictions. Is that fine or do you have known issues with newer versions?