### PR TITLE
Handle error "[-] Masterkey.__init__() missing 2 required positional arguments: 'blob' and 'sid'" case when  -mkfile is used.

### DIFF
--- a/dploot/triage/masterkeys.py
+++ b/dploot/triage/masterkeys.py
@@ -27,8 +27,8 @@ class Masterkey:
 
         self.key = key
         self._sha1 = sha1
-
-        self.generate_hash()
+        if self.blob is not None:
+            self.generate_hash()
 
     def __str__(self) -> str:
         return f"{{{self.guid}}}:{self.sha1}" if self.key is not None else ""
@@ -91,6 +91,8 @@ def parse_masterkey_file(filename) -> List[Masterkey]:
         masterkeys.append(
             Masterkey(
                 guid=find_guid(guid),
+                blob=None,
+                sid=None,
                 sha1=find_sha1(sha1),
             )
         )


### PR DESCRIPTION
The new Masterkey constructor does not provide a default value for sid and blob, leading to an error when -mkfile are used.

Also, the generate_hash function is called in the __init__ function but its results is not used. It uses the blob so I added an if case but maybe it should be removed ?