### PR TITLE
impacket 0.13 changes API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dploot = "dploot.entry:main"
 
 [tool.poetry.dependencies]
 python = "^3.10.0"
-impacket = ">=0.12.0"
+impacket = "==0.12.0"
 cryptography = ">=40.0.1"
 pyasn1 = ">=0.4.8"
 lxml = ">=5.0"


### PR DESCRIPTION
impacket 0.13 introduces changes in the SMB API, specificaly in [smb.SharedFile](https://github.com/fortra/impacket/commit/ff8c200fd040b04d3b5ff05449646737f836235d), which are incompatible with the current implementation  of DPLootSMBConnection.

This instructs pip(x) to always use impacket version 0.12.0
